### PR TITLE
support qtwebkit2.2

### DIFF
--- a/src/js/Contemplate.js
+++ b/src/js/Contemplate.js
@@ -43,7 +43,7 @@
         Obj = Object, Arr = Array, Str = String, Func = Function, 
         Keys = Obj.keys, parse_int = parseInt, parse_float = parseFloat,
         OP = Obj[PROTO], AP = Arr[PROTO], FP = Func[PROTO],
-        _toString = OP.toString, slice = FP.call.bind(AP.slice),
+        _toString = OP.toString, slice = AP.slice,
         isNode = "undefined" !== typeof(global) && '[object global]' === _toString.call(global),
         userAgent = "undefined"!==typeof(navigator) ? navigator.userAgent : "",
         isChrome = /Chrome\//.test(userAgent),


### PR DESCRIPTION
Hi, I would like to use this library in qtwebkit2.2 (an old version browser)

Because the prototype.bind is not supported by this browser so I replaced the code
line 46: slice = FP.call.bind(AP.slice) by slice = AP.slice

I don't know if this will cause performance problem or not?
